### PR TITLE
Speed up flood fill using priority queue and grids

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -389,16 +389,17 @@ void inventory::form_from_map( map &m, const tripoint &origin, int range, bool a
 {
     // populate a grid of spots that can be reached
     std::vector<tripoint> reachable_pts = {};
-    m.reachable_flood_steps( reachable_pts, origin, range, 1, 100 );
+    // If we need a clear path we care about the reachability of points
+    if( clear_path ) {
+        m.reachable_flood_steps( reachable_pts, origin, range, 1, 100 );
+    } else {
+        // Fill reachable points with points_in_radius
+        tripoint_range in_radius = m.points_in_radius( origin, range );
+        reachable_pts.insert( reachable_pts.begin(), in_radius.begin(), in_radius.end() );
+    }
 
     items.clear();
-    for( const tripoint &p : m.points_in_radius( origin, range ) ) {
-        // can not reach this -> can not access its contents
-        if( clear_path ) {
-            if( origin != p && !m.check_reachables( reachable_pts, p ) ) {
-                continue;
-            }
-        }
+    for( const tripoint &p : reachable_pts ) {
         if( m.has_furn( p ) ) {
             const furn_t &f = m.furn( p ).obj();
             const itype *type = f.crafting_pseudo_item_type();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <iterator>
 #include <limits>
+#include <queue>
 #include <sstream>
 #include <type_traits>
 #include <unordered_map>
@@ -6210,40 +6211,108 @@ std::vector<tripoint> map::find_clear_path( const tripoint &source,
 void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tripoint &f,
                                  int range, const int cost_min, const int cost_max ) const
 {
-    // the starting spot for the search should definitely be included
-    reachable_pts.push_back( f );
-    std::vector < std::pair<tripoint, int>> f_map = { {f, 0} };
-    // iterate out to the maximum number of steps
-    for( unsigned int r = 1; r < range; r++ ) {
-        int f_map_size = f_map.size();
-        for( unsigned int k = 0; k < f_map_size; k++ ) {
-            for( int i = -1; i <= 1; i++ ) {
-                for( int j = -1; j <= 1; j++ ) {
-                    tripoint tp = { f_map[k].first.x + i, f_map[k].first.y + j, f.z };
-                    const int cost = this->move_cost( { tp.x, tp.y, tp.z } );
-                    // rejection conditions
-                    if( ( tp.x == f_map[k].first.x && tp.y == f_map[k].first.y ) ||
-                        cost < cost_min || cost > cost_max || !has_floor_or_support( tp ) ) {
-                        continue;
-                    } else {
-                        // now make sure we haven't already stepped on this spot
-                        bool np = true;
-                        for( unsigned int l = 0; l < f_map.size(); l++ ) {
-                            if( tp == f_map[l].first ) {
-                                np = false;
-                                break;
-                            }
-                        }
-                        if( !np ) {
-                            continue;
-                        } else {
-                            // add this point to our lists of reachables
-                            f_map.push_back( { tp, r } );
-                            reachable_pts.push_back( tp );
+    struct pq_item {
+        int dist;
+        int ndx;
+    };
+    struct pq_item_comp {
+        bool operator()( const pq_item &left, const pq_item &right ) {
+            return left.dist > right.dist;
+        }
+    };
+    using PQ_type = std::priority_queue< pq_item, std::vector<pq_item>, pq_item_comp>;
+
+    // temp buffer for grid
+    const int grid_dim = range * 2 + 1;
+    std::vector< int > t_grid( grid_dim * grid_dim, -1 ); // init to -1 as "not visited yet"
+    const tripoint origin_offset = {range, range, 0};
+    const int initial_visit_distance = range * range; // Large unreachable value
+
+    // Fill positions that are visitable with initial_visit_distance
+    for( const tripoint &p : points_in_radius( f, range ) ) {
+        const tripoint tp = { p.x, p.y, f.z };
+        const int tp_cost = move_cost( tp );
+        // rejection conditions
+        if( tp_cost < cost_min || tp_cost > cost_max || !has_floor_or_support( tp ) ) {
+            continue;
+        }
+        // set initial cost for grid point
+        tripoint origin_relative = tp - f;
+        origin_relative += origin_offset;
+        int ndx = origin_relative.x + origin_relative.y * grid_dim;
+        t_grid[ ndx ] = initial_visit_distance;
+    }
+    
+    auto gen_neighbors = []( const pq_item &elem, int grid_dim, pq_item *neighbors ) {
+        // Up to 8 neighbors
+        int new_cost = elem.dist + 1;
+        int ox[8] = {
+            -1, 0, 1,
+            -1,    1,
+            -1, 0, 1
+        };
+        int oy[8] = {
+            -1, -1, -1,
+             0,      0,
+             1,  1,  1
+        };
+
+        int ex = elem.ndx % grid_dim;
+        int ey = elem.ndx / grid_dim;
+        for( int i = 0; i < 8; ++i ) {
+            int nx = ex + ox[i];
+            int ny = ey + oy[i];
+
+            int ndx = nx + ny * grid_dim;
+            neighbors[i] = { new_cost, ndx };
+        }
+    };
+
+    PQ_type pq( pq_item_comp{} );
+    pq_item first_item{ 0, range + range * grid_dim };
+    pq.push( first_item );
+    pq_item neighbor_elems[8];
+
+    while( !pq.empty() ) {
+        const pq_item item = pq.top();
+        pq.pop();
+
+        if( t_grid[ item.ndx ] == initial_visit_distance ) {
+            t_grid[ item.ndx ] = item.dist;
+            if( item.dist + 1 < range ) {
+                gen_neighbors( item, grid_dim, neighbor_elems );
+                for( int i = 0; i < 8; ++i ) {
+                    pq.push( neighbor_elems[i] );
+                }
+            }
+        }
+    }
+    std::vector<char> o_grid( grid_dim * grid_dim, 0 );
+    for( int y = 0, ndx = 0; y < grid_dim; ++y ) {
+        for( int x = 0; x < grid_dim; ++x, ++ndx ) {
+            if( t_grid[ ndx ] != -1 && t_grid[ ndx ] < initial_visit_distance ) {
+                // set self and neighbors to 1
+                for( int dy = -1; dy <= 1; ++dy ) {
+                    for( int dx = -1; dx <= 1; ++dx ) {
+                        int tx = dx + x;
+                        int ty = dy + y;
+
+                        if( tx >= 0 && tx < grid_dim && ty >= 0 && ty < grid_dim ) {
+                            o_grid[ tx + ty * grid_dim ] = 1;
                         }
                     }
                 }
-
+            }
+        }
+    }
+    // Remove origin from output set
+    o_grid[ range + range * grid_dim ] = 0;
+    // Now go over again to pull out all of the reachable points
+    for( int y = 0, ndx = 0; y < grid_dim; ++y ) {
+        for( int x = 0; x < grid_dim; ++x, ++ndx ) {
+            if( o_grid[ ndx ] ) {
+                tripoint t = f - origin_offset + tripoint{ x, y, 0 };
+                reachable_pts.push_back( t );
             }
         }
     }
@@ -6252,7 +6321,7 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
 bool map::check_reachables( const std::vector<tripoint> &reachable_pts, const tripoint &f ) const
 {
     const int s = reachable_pts.size();
-    for( unsigned int i = 0; i < s; i++ ) {
+    for( int i = 0; i < s; i++ ) {
         // if we can physically walk to a spot, then we can grab things from it's neighboring tiles too
         if( reachable_pts[i] == f || ( abs( f.x - reachable_pts[i].x ) <= 1 &&
                                        abs( f.y - reachable_pts[i].y ) <= 1 ) ) {

--- a/src/map.h
+++ b/src/map.h
@@ -502,7 +502,7 @@ class map
          * 1. Checks if a point is reachable using a flood fill and if it is, adds it to a vector.
          *
          */
-        void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tripoint &f,
+        void reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tripoint &f,
                                          const int range,
                                          const int cost_min, const int cost_max ) const;
 
@@ -512,7 +512,7 @@ class map
         * Does the following:
         * 1. iterates over 'reachable_pts' and returns true if 'f' is in 'reachable_pts'
         */
-        bool map::check_reachables( const std::vector<tripoint> &reachable_pts, const tripoint &f ) const;
+        bool check_reachables( const std::vector<tripoint> &reachable_pts, const tripoint &f ) const;
 
         /**
          * Iteratively tries Bresenham lines with different biases


### PR DESCRIPTION
#### Summary
```SUMMARY: Performance "Speed up flood fill in inventory::form_from_map"```

#### Purpose of change
In the extremely large range case (eg R=20, R=50) iterating over tripoints to see if a candidate point has been picked already is slow.

#### Describe the solution
Precondition data to fit in a grid, then run a breadth-first undirected search to find all connected points to the origin. Then expand each of these connected points to include their adjacent points to remove the need to check inside of the loop.

Only need to run the flood fill if `clear_path == true`. If it is `false` we want everything in the range and can just use the points in radius. Conditioning the data earlier hoists loop invariants, removes branching, and speeds things up.

#### Describe alternatives you've considered
Leave it alone: the only time we need to actually do the flood fill, in the current state of the code, is at Range = 6 the current solution is probably fast enough. 

#### Additional context
```
PROFILE RESULTS [R=50] (Current Implementation)
26188758955 ns : inventory::form_from_map
26149242731 ns : inventory::form_from_map


PROFILE RESULTS [R=50] (PR Implementation)
   29070601 ns : inventory::form_from_map
   27311804 ns : inventory::form_from_map
   34487237 ns : inventory::form_from_map
```